### PR TITLE
Feature/20 rayon parallelism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1714,6 +1714,7 @@ version = "0.0.2"
 dependencies = [
  "rayon",
  "serde_json",
+ "sha3",
  "solana-program",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1712,6 +1712,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 name = "hashsigs-rs"
 version = "0.0.2"
 dependencies = [
+ "rayon",
  "serde_json",
  "solana-program",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
 
 [dependencies]
 rayon = { version = "1.8", optional = true }
+sha3 = "0.10"
 
 [dev-dependencies]
 solana-program = "2.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
 ]
 
 [dependencies]
+rayon = { version = "1.8", optional = true }
 
 [dev-dependencies]
 solana-program = "2.3"
@@ -29,3 +30,4 @@ serde_json = "1.0.143"
 [features]
 default = ["solana"]
 solana = []
+parallel = ["rayon"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,7 @@ members = [
 [dev-dependencies]
 solana-program = "2.3"
 serde_json = "1.0.143"
+
+[features]
+default = ["solana"]
+solana = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,66 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
-
 //! WOTS+ (Winternitz One-Time Signature Plus) implementation
+
+
+enum SignatureBufferEnum {
+    #[cfg(feature = "solana")]
+    Array {
+        buf: [u8; constants::SIGNATURE_SIZE],
+        len: usize,
+    },
+
+    #[cfg(not(feature = "solana"))]
+    Vec(Vec<u8>),
+}
+
+impl SignatureBufferEnum {
+    fn new() -> Self {
+        #[cfg(feature = "solana")]
+        {
+            Self::Array {
+                buf: [0u8; constants::SIGNATURE_SIZE],
+                len: 0,
+            }
+        }
+
+        #[cfg(not(feature = "solana"))]
+        {
+            Self::Vec(Vec::with_capacity(constants::SIGNATURE_SIZE))
+        }
+    }
+
+    fn push_slice(&mut self, data: &[u8]) {
+        #[cfg(feature = "solana")]
+        {
+            let Self::Array { buf, len } = self;
+            let end = *len + data.len();
+            buf[*len..end].copy_from_slice(data);
+            *len = end;
+        }
+
+        #[cfg(not(feature = "solana"))]
+        {
+            let Self::Vec(v) = self;
+            v.extend_from_slice(data);
+        }
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        #[cfg(feature = "solana")]
+        {
+            let Self::Array { buf, len } = self;
+            &buf[..*len]
+        }
+
+        #[cfg(not(feature = "solana"))]
+        {
+            let Self::Vec(v) = self;
+            v.as_slice()
+        }
+    }
+}
 
 /// Hash function type for WOTS+
 type HashFn = fn(&[u8]) -> [u8; 32];
@@ -252,7 +310,7 @@ impl WOTSPlus {
         let randomization_elements = self.generate_randomization_elements(&public_seed);
         let function_key = randomization_elements[0];
 
-        let mut public_key_segments = Vec::with_capacity(constants::SIGNATURE_SIZE);
+        let mut public_key_segments = SignatureBufferEnum::new();
 
         for i in 0..constants::NUM_SIGNATURE_CHUNKS {
             let mut to_hash = vec![0u8; constants::HASH_LEN * 2];
@@ -267,10 +325,10 @@ impl WOTSPlus {
                 (constants::CHAIN_LEN - 1) as u16,
             );
             
-            public_key_segments.extend_from_slice(&segment);
+            public_key_segments.push_slice(&segment);
         }
 
-        let public_key_hash = (self.hash_fn)(&public_key_segments);
+        let public_key_hash = (self.hash_fn)(public_key_segments.as_slice());
         
         PublicKey {
             public_seed: *public_seed,
@@ -353,7 +411,7 @@ impl WOTSPlus {
         
         let chain_segments = self.compute_message_hash_chain_indexes(message);
         
-        let mut public_key_segments = Vec::with_capacity(constants::SIGNATURE_SIZE);
+        let mut public_key_segments = SignatureBufferEnum::new();
 
         // Compute each public key segment. These are done by taking the signature, which is prevChainOut at chainIdx,
         // and completing the hash chain via the chain function to recompute the public key segment.
@@ -366,11 +424,11 @@ impl WOTSPlus {
                 num_iterations,
             );
             
-            public_key_segments.extend_from_slice(&segment);
+            public_key_segments.push_slice(&segment);
         }
 
         // Hash all public key segments together to recreate the original public key
-        let computed_hash = (self.hash_fn)(&public_key_segments);
+        let computed_hash = (self.hash_fn)(public_key_segments.as_slice());
         
         // Compare computed hash with stored public key hash
         computed_hash == public_key.public_key_hash
@@ -397,7 +455,7 @@ impl WOTSPlus {
         }
 
         let chain_segments = self.compute_message_hash_chain_indexes(message);
-        let mut public_key_segments = [0u8; constants::SIGNATURE_SIZE];
+        let mut public_key_segments = SignatureBufferEnum::new();
         
         // Compute each public key segment using the pre-computed randomization elements
         for (i, &chain_idx) in chain_segments.iter().enumerate() {
@@ -409,12 +467,12 @@ impl WOTSPlus {
                 num_iterations,
             );
             
-            let offset = i * constants::HASH_LEN;
-            public_key_segments[offset..offset + constants::HASH_LEN].copy_from_slice(&segment);
+            // let offset = i * constants::HASH_LEN;
+            public_key_segments.push_slice(&segment);
         }
 
         // Hash all public key segments together and compare with the provided hash
-        let computed_hash = (self.hash_fn)(&public_key_segments);
+        let computed_hash = (self.hash_fn)(public_key_segments.as_slice());
         computed_hash == *public_key_hash
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! WOTS+ (Winternitz One-Time Signature Plus) implementation
 
 
-enum SignatureBufferEnum {
+enum SignatureBuffer {
     #[cfg(feature = "solana")]
     Array {
         buf: [u8; constants::SIGNATURE_SIZE],
@@ -28,7 +28,7 @@ enum SignatureBufferEnum {
     Vec(Vec<u8>),
 }
 
-impl SignatureBufferEnum {
+impl SignatureBuffer {
     fn new() -> Self {
         #[cfg(feature = "solana")]
         {
@@ -310,7 +310,7 @@ impl WOTSPlus {
         let randomization_elements = self.generate_randomization_elements(&public_seed);
         let function_key = randomization_elements[0];
 
-        let mut public_key_segments = SignatureBufferEnum::new();
+        let mut public_key_segments = SignatureBuffer::new();
 
         for i in 0..constants::NUM_SIGNATURE_CHUNKS {
             let mut to_hash = vec![0u8; constants::HASH_LEN * 2];
@@ -411,7 +411,7 @@ impl WOTSPlus {
         
         let chain_segments = self.compute_message_hash_chain_indexes(message);
         
-        let mut public_key_segments = SignatureBufferEnum::new();
+        let mut public_key_segments = SignatureBuffer::new();
 
         // Compute each public key segment. These are done by taking the signature, which is prevChainOut at chainIdx,
         // and completing the hash chain via the chain function to recompute the public key segment.
@@ -455,7 +455,7 @@ impl WOTSPlus {
         }
 
         let chain_segments = self.compute_message_hash_chain_indexes(message);
-        let mut public_key_segments = SignatureBufferEnum::new();
+        let mut public_key_segments = SignatureBuffer::new();
         
         // Compute each public key segment using the pre-computed randomization elements
         for (i, &chain_idx) in chain_segments.iter().enumerate() {
@@ -548,6 +548,65 @@ mod tests {
         assert_eq!(recovered.public_key_hash, public_key.public_key_hash);
     }
 
+    #[test]
+    fn signatures_are_deterministic() {
+        let wots = WOTSPlus::new(mock_hash);
+
+        let seed = [9u8; 32];
+        let (_, sk) = wots.generate_key_pair(&seed);
+        let msg = [1u8; constants::MESSAGE_LEN];
+
+        let sig1 = wots.sign(&sk, &msg);
+        let sig2 = wots.sign(&sk, &msg);
+
+        assert_eq!(sig1, sig2);
+    }
+
+
+    #[test]
+    fn sigbuf_appends_correctly() {
+        let mut buf = SignatureBuffer::new();
+
+        let a = [1u8; constants::HASH_LEN];
+        let b = [2u8; constants::HASH_LEN];
+
+        buf.push_slice(&a);
+        buf.push_slice(&b);
+
+        let out = buf.as_slice();
+        assert_eq!(out.len(), 2 * constants::HASH_LEN);
+        assert_eq!(&out[..constants::HASH_LEN], &a);
+        assert_eq!(&out[constants::HASH_LEN..], &b);
+    }
+
+    #[cfg(feature = "solana")]
+    #[test]
+    #[should_panic]
+    fn sigbuf_panics_on_overflow() {
+        let mut buf = SignatureBuffer::new();
+        let chunk = [0u8; constants::HASH_LEN];
+
+        for _ in 0..(constants::NUM_SIGNATURE_CHUNKS + 1) {
+            buf.push_slice(&chunk);
+        }
+    }
+
+    #[cfg(not(feature = "solana"))]
+    #[test]
+    fn sigbuf_allows_growth_on_heap() {
+        let mut buf = SignatureBuffer::new();
+        let chunk = [0u8; constants::HASH_LEN];
+
+        for _ in 0..(constants::NUM_SIGNATURE_CHUNKS + 10) {
+            buf.push_slice(&chunk);
+        }
+
+        assert_eq!(
+            buf.as_slice().len(),
+            (constants::NUM_SIGNATURE_CHUNKS + 10) * constants::HASH_LEN
+        );
+    }
+    
     #[cfg(test)]
     mod tests {
         use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //! WOTS+ (Winternitz One-Time Signature Plus) implementation
 
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+
+#[cfg(all(feature = "parallel", feature = "solana"))]
+compile_error!("parallel and solana cannot be enabled at the same time");
 
 enum SignatureBuffer {
 
@@ -30,6 +35,8 @@ enum SignatureBuffer {
 }
 
 impl SignatureBuffer {
+
+
     fn new() -> Self {
         #[cfg(feature = "solana")]
         {
@@ -42,6 +49,20 @@ impl SignatureBuffer {
                 buf: [0u8; constants::SIGNATURE_SIZE],
                 len: 0,
             }
+        }
+    }
+
+    fn len(&self) -> usize {
+        #[cfg(feature = "solana")]
+        {
+            let Self::Vec(v) = self;
+            v.len()
+        }
+
+        #[cfg(not(feature = "solana"))]
+        {
+            let Self::Array { len, .. } = self;
+            *len
         }
     }
 
@@ -269,9 +290,11 @@ impl WOTSPlus {
     /// XOR two 32-byte arrays
     fn xor(a: &[u8; constants::HASH_LEN], b: &[u8; constants::HASH_LEN]) -> [u8; constants::HASH_LEN] {
         let mut result = [0u8; constants::HASH_LEN];
+
         for i in 0..constants::HASH_LEN {
             result[i] = a[i] ^ b[i];
         }
+
         result
     }
 
@@ -292,6 +315,34 @@ impl WOTSPlus {
             chain_out = (self.hash_fn)(&xored);
         }
         chain_out
+    }
+
+    fn compute_chain_segment(
+        &self,
+        i: u16,
+        private_key: &[u8; constants::HASH_LEN],
+        randomization_elements: &[[u8; constants::HASH_LEN]],
+        chain_idx: u16,
+        steps: u16,
+    ) -> [u8; constants::HASH_LEN] {
+        let function_key = randomization_elements[0];
+
+        let mut to_hash = vec![0u8; constants::HASH_LEN * 2];
+
+        to_hash[..constants::HASH_LEN]
+            .copy_from_slice(&function_key);
+
+        to_hash[constants::HASH_LEN..]
+            .copy_from_slice(&self.prf(private_key, (i + 1) as u16));
+
+        let secret_key_segment = (self.hash_fn)(&to_hash);
+
+        self.chain(
+            &secret_key_segment,
+            &randomization_elements,
+            chain_idx as u16, 
+            steps,
+        )
     }
 
     /// Compute message hash chain indexes
@@ -401,25 +452,50 @@ impl WOTSPlus {
 
         let public_seed = self.prf(private_key, 0);
         let randomization_elements = self.generate_randomization_elements(&public_seed);
-        let function_key = randomization_elements[0];
         
         let chain_segments = self.compute_message_hash_chain_indexes(message);
+        
         let mut signature = SignatureBuffer::new();
 
-        for (i, &chain_idx) in chain_segments.iter().enumerate() {
-            let mut to_hash = vec![0u8; constants::HASH_LEN * 2];
-            to_hash[..constants::HASH_LEN].copy_from_slice(&function_key);
-            to_hash[constants::HASH_LEN..].copy_from_slice(&self.prf(private_key, (i + 1) as u16));
+        #[cfg(feature = "parallel")]{      
+
+            let segments: Vec<[u8; constants::HASH_LEN]> = 
+            chain_segments
+                .par_iter()
+                .enumerate()
+                .map(|(i, &chain_idx)| {
+
+                    self.compute_chain_segment(
+                        i as u16,
+                        private_key,
+                        &randomization_elements,
+                        0,
+                        chain_idx as u16,
+                    )
+
+                }).collect();
+
             
-            let secret_key_segment = (self.hash_fn)(&to_hash);
-            let sig_segment = self.chain(
-                &secret_key_segment,
-                &randomization_elements,
-                0,
-                chain_idx as u16,
-            );
-            signature.push_slice(&sig_segment);
+            for segment in segments {
+               signature.push_slice(&segment);
+            }
         }
+
+        #[cfg(not(feature = "parallel"))]
+        {
+            for (i, &chain_idx) in chain_segments.iter().enumerate() {
+
+                let sig_segment = self.compute_chain_segment(
+                        i as u16,
+                        private_key,
+                        &randomization_elements,
+                        0,
+                        chain_idx as u16,
+                    );
+                signature.push_slice(&sig_segment);
+            }
+        }
+
 
         signature.as_signature_chunks()
     }
@@ -433,7 +509,7 @@ impl WOTSPlus {
     /// 5. Run the chain function on each segment to reproduce each public key segment
     /// 6. Hash all public key segments together to recreate the original public key
     pub fn verify(&self, public_key: &PublicKey, message: &[u8], signature: &Vec<[u8; constants::HASH_LEN]>) -> bool {
-        
+
         if message.len() != constants::MESSAGE_LEN {
             return false;
         }
@@ -443,29 +519,12 @@ impl WOTSPlus {
 
         let randomization_elements = self.generate_randomization_elements(&public_key.public_seed);
         
-        let chain_segments = self.compute_message_hash_chain_indexes(message);
-        
-        let mut public_key_segments = SignatureBuffer::new();
-
-        // Compute each public key segment. These are done by taking the signature, which is prevChainOut at chainIdx,
-        // and completing the hash chain via the chain function to recompute the public key segment.
-        for (i, &chain_idx) in chain_segments.iter().enumerate() {
-            let num_iterations = (constants::CHAIN_LEN - 1 - chain_idx as usize) as u16;
-            let segment = self.chain(
-                &signature[i],
-                &randomization_elements,
-                chain_idx as u16,
-                num_iterations,
-            );
-            
-            public_key_segments.push_slice(&segment);
-        }
-
-        // Hash all public key segments together to recreate the original public key
-        let computed_hash = (self.hash_fn)(public_key_segments.as_slice());
-        
-        // Compare computed hash with stored public key hash
-        computed_hash == public_key.public_key_hash
+        self.verify_with_randomization_elements(
+            &public_key.public_key_hash,
+            message,
+            signature,
+            &randomization_elements,
+        )
     }
 
     /// Verify a WOTS+ signature using pre-computed randomization elements
@@ -491,18 +550,45 @@ impl WOTSPlus {
         let chain_segments = self.compute_message_hash_chain_indexes(message);
         let mut public_key_segments = SignatureBuffer::new();
         
-        // Compute each public key segment using the pre-computed randomization elements
-        for (i, &chain_idx) in chain_segments.iter().enumerate() {
-            let num_iterations = (constants::CHAIN_LEN - 1 - chain_idx as usize) as u16;
-            let segment = self.chain(
-                &signature[i],
-                randomization_elements,
-                chain_idx as u16,
-                num_iterations,
-            );
-            
-            // let offset = i * constants::HASH_LEN;
-            public_key_segments.push_slice(&segment);
+
+        #[cfg(feature = "parallel")]{      
+            let segments: Vec<[u8; constants::HASH_LEN]> = 
+            chain_segments
+                .par_iter()
+                .enumerate()
+                .map(|(i, &chain_idx)| {
+
+                    let num_iterations = (constants::CHAIN_LEN - 1 - chain_idx as usize) as u16;
+                    self.chain(
+                        &signature[i],
+                        &randomization_elements,
+                        chain_idx as u16,
+                        num_iterations,
+                    )
+                }).collect();
+
+
+            for segment in segments {
+               public_key_segments.push_slice(&segment);
+            }
+        }
+
+        #[cfg(not(feature = "parallel"))]
+        {
+            // Compute each public key segment. These are done by taking the signature, which is prevChainOut at chainIdx,
+            // and completing the hash chain via the chain function to recompute the public key segment.
+            for (i, &chain_idx) in chain_segments.iter().enumerate() {
+                let num_iterations = (constants::CHAIN_LEN - 1 - chain_idx as usize) as u16;
+                let segment = self.chain(
+                    &signature[i],
+                    &randomization_elements,
+                    chain_idx as u16,
+                    num_iterations,
+                );
+                
+                public_key_segments.push_slice(&segment);
+            }
+
         }
 
         // Hash all public key segments together and compare with the provided hash

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,59 +18,65 @@
 
 
 enum SignatureBuffer {
+
     #[cfg(feature = "solana")]
+    Vec(Vec<u8>),
+
+    #[cfg(not(feature = "solana"))]
     Array {
         buf: [u8; constants::SIGNATURE_SIZE],
         len: usize,
     },
-
-    #[cfg(not(feature = "solana"))]
-    Vec(Vec<u8>),
 }
 
 impl SignatureBuffer {
     fn new() -> Self {
         #[cfg(feature = "solana")]
         {
-            Self::Array {
-                buf: [0u8; constants::SIGNATURE_SIZE],
-                len: 0,
-            }
+            Self::Vec(Vec::with_capacity(constants::SIGNATURE_SIZE))
         }
 
         #[cfg(not(feature = "solana"))]
         {
-            Self::Vec(Vec::with_capacity(constants::SIGNATURE_SIZE))
+            Self::Array {
+                buf: [0u8; constants::SIGNATURE_SIZE],
+                len: 0,
+            }
         }
     }
 
     fn push_slice(&mut self, data: &[u8]) {
         #[cfg(feature = "solana")]
         {
-            let Self::Array { buf, len } = self;
-            let end = *len + data.len();
-            buf[*len..end].copy_from_slice(data);
-            *len = end;
+            let Self::Vec(v) = self;
+            let new_len = v.len() + data.len();
+            assert!(
+                new_len <= constants::SIGNATURE_SIZE,
+                "SignatureBuffer overflow"
+            );
+            v.extend_from_slice(data);
         }
 
         #[cfg(not(feature = "solana"))]
         {
-            let Self::Vec(v) = self;
-            v.extend_from_slice(data);
+            let Self::Array { buf, len } = self;
+            let end = *len + data.len();
+            buf[*len..end].copy_from_slice(data);
+            *len = end;
         }
     }
 
     fn as_slice(&self) -> &[u8] {
         #[cfg(feature = "solana")]
         {
-            let Self::Array { buf, len } = self;
-            &buf[..*len]
+            let Self::Vec(v) = self;
+            v.as_slice()
         }
 
         #[cfg(not(feature = "solana"))]
         {
-            let Self::Vec(v) = self;
-            v.as_slice()
+            let Self::Array { buf, len } = self;
+            &buf[..*len]
         }
     }
 }
@@ -579,10 +585,10 @@ mod tests {
         assert_eq!(&out[constants::HASH_LEN..], &b);
     }
 
-    #[cfg(feature = "solana")]
+    #[cfg(not(feature = "solana"))]
     #[test]
     #[should_panic]
-    fn sigbuf_panics_on_overflow() {
+    fn sigbuf_panics_on_overflow_non_solana() {
         let mut buf = SignatureBuffer::new();
         let chunk = [0u8; constants::HASH_LEN];
 
@@ -591,22 +597,18 @@ mod tests {
         }
     }
 
-    #[cfg(not(feature = "solana"))]
+    #[cfg(feature = "solana")]
     #[test]
-    fn sigbuf_allows_growth_on_heap() {
+    #[should_panic]
+    fn sigbuf_panics_on_overflow_solana() {
         let mut buf = SignatureBuffer::new();
         let chunk = [0u8; constants::HASH_LEN];
 
-        for _ in 0..(constants::NUM_SIGNATURE_CHUNKS + 10) {
+        for _ in 0..(constants::NUM_SIGNATURE_CHUNKS + 1) {
             buf.push_slice(&chunk);
         }
-
-        assert_eq!(
-            buf.as_slice().len(),
-            (constants::NUM_SIGNATURE_CHUNKS + 10) * constants::HASH_LEN
-        );
     }
-    
+
     #[cfg(test)]
     mod tests {
         use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,7 @@
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
-
-#[cfg(all(feature = "parallel", feature = "solana"))]
-compile_error!("parallel and solana cannot be enabled at the same time");
+use std::time::Instant;
 
 enum SignatureBuffer {
 
@@ -610,6 +608,18 @@ mod tests {
         output
     }
 
+    use sha3::{Digest, Keccak256};
+
+    fn keccak256_hash(data: &[u8]) -> [u8; 32] {
+        let mut hasher = Keccak256::new();
+        hasher.update(data);
+        let result = hasher.finalize();
+
+        let mut output = [0u8; 32];
+        output.copy_from_slice(&result);
+        output
+    }
+
     #[test]
     fn test_constants() {
         assert_eq!(constants::HASH_LEN, 32);
@@ -622,7 +632,8 @@ mod tests {
 
     #[test]
     fn test_key_generation_and_signing() {
-        let wots = WOTSPlus::new(mock_hash);
+        let start = Instant::now();
+        let wots = WOTSPlus::new(keccak256_hash);
         let private_seed = [1u8; 32];
         let (public_key, private_key) = wots.generate_key_pair(&private_seed);
         
@@ -630,6 +641,8 @@ mod tests {
         let signature = wots.sign(&private_key, &message);
         
         assert!(wots.verify(&public_key, &message, &signature));
+
+        println!("Time with Keccak256 : {:?}", start.elapsed());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,32 @@ impl SignatureBuffer {
             &buf[..*len]
         }
     }
+
+    /// Consume the buffer and return its contents as a Vec<u8>
+    fn as_signature_chunks(self) -> Vec<[u8; constants::HASH_LEN]> {
+        let slice = match self {
+            #[cfg(feature = "solana")]
+            SignatureBuffer::Vec(v) => v,
+
+            #[cfg(not(feature = "solana"))]
+            SignatureBuffer::Array { buf, len } => buf[..len].to_vec(),
+        };
+        // Enforce chunk alignment invariant
+        assert!(
+            slice.len() % constants::HASH_LEN == 0,
+            "SignatureBuffer length is not chunk-aligned"
+        );
+
+        slice
+            .chunks_exact(constants::HASH_LEN)
+            .map(|chunk| {
+                let mut arr = [0u8; constants::HASH_LEN];
+                arr.copy_from_slice(chunk);
+                arr
+            })
+            .collect()
+    }
+
 }
 
 /// Hash function type for WOTS+
@@ -231,11 +257,13 @@ impl WOTSPlus {
         &self,
         public_seed: &[u8; constants::HASH_LEN]
     ) -> Vec<[u8; constants::HASH_LEN]> {
-        let mut elements = Vec::with_capacity(constants::NUM_SIGNATURE_CHUNKS);
+              
+        let mut elements = SignatureBuffer::new();
         for i in 0..constants::NUM_SIGNATURE_CHUNKS {
-            elements.push(self.prf(public_seed, i as u16));
+            elements.push_slice(&self.prf(public_seed, i as u16));
         }
-        elements
+        elements.as_signature_chunks()
+        
     }
 
     /// XOR two 32-byte arrays
@@ -376,7 +404,7 @@ impl WOTSPlus {
         let function_key = randomization_elements[0];
         
         let chain_segments = self.compute_message_hash_chain_indexes(message);
-        let mut signature = Vec::with_capacity(constants::NUM_SIGNATURE_CHUNKS);
+        let mut signature = SignatureBuffer::new();
 
         for (i, &chain_idx) in chain_segments.iter().enumerate() {
             let mut to_hash = vec![0u8; constants::HASH_LEN * 2];
@@ -390,10 +418,10 @@ impl WOTSPlus {
                 0,
                 chain_idx as u16,
             );
-            signature.push(sig_segment);
+            signature.push_slice(&sig_segment);
         }
 
-        signature
+        signature.as_signature_chunks()
     }
 
     /// Verify a WOTS+ signature


### PR DESCRIPTION
## Summary

This MR introduces an optional parallel feature using Rayon to enable parallel computation of WOTS+ chain segments while preserving deterministic ordering and RFC-compatible behavior.

## Changes

+ Optional parallel feature (Rayon-based)
+ Refactored chain segment computation to use:
      + par_iter().map().collect() 
     + Sequential fallback when parallel is disabled
+ Minor cleanup, removed duplicate code in verify() and verify_with_randomization_elements() and safety assertions
+ Keccak256 function to compare the performace of parallel and sequential flows (Later we should consider proper benchmarking using criterion) 

## Security & Correctness Notes

- Parallelization only applied at chain-segment level (outer loop)
- Internal hash-chain loop remains sequential (cryptographically required)
- Output ordering preserved (Rayon collect() guarantees order)
- No shared mutable state in parallel blocks
- Signature size invariants maintained

## Testing

Tested with:
```
cargo test
cargo test --features parallel
cargo test --no-default-features --features parallel
```
All tests pass in both sequential and parallel modes.