### PR TITLE
chore: drop no-op as_ref calls in processor

### DIFF
--- a/solana/src/processor.rs
+++ b/solana/src/processor.rs
@@ -155,7 +155,7 @@ fn process_sign(
         &[
             b"signature",
             signer.key.as_ref(),
-            message.as_ref(),
+            message,
         ],
         program_id
     );
@@ -194,7 +194,7 @@ fn process_sign(
             &[&[
                 b"signature",
                 signer.key.as_ref(),
-                message.as_ref(),
+                message,
                 &[bump_seed],
             ]],
         )?;


### PR DESCRIPTION
Clears two clippy::useless_asref warnings so `cargo clippy --workspace --all-targets -- -D warnings` passes. Type-preserving; full test suite unchanged at 89 passing.