### PR TITLE
deps: bump bytemuck_derive to 1.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.10.1"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/solana/Cargo.toml
+++ b/solana/Cargo.toml
@@ -17,7 +17,7 @@ solana-program = "2.3"
 hashsigs-rs = { path = ".." }
 borsh = "1.5.7"
 bytemuck = "1.23"
-bytemuck_derive = "1.10.1"  # Updated to satisfy Solana 2.3
+bytemuck_derive = "1.10.2"  # Updated to satisfy Solana 2.3
 solana-system-interface = "2.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Regenerated against current main. Supersedes #15, whose lockfile predates the SHRINCS refactor. Verified locally: full workspace test suite passes (no GitHub Actions exist in this repo).