### PR TITLE
deps: bump serde_json to 1.0.145

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3751,14 +3751,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,6 @@ tsify = { version = "=0.5.5", default-features = false, features = ["js"], optio
 wasm-bindgen = { version = "=0.2.100", optional = true }
 
 [dev-dependencies]
-serde_json = "1.0.143"
+serde_json = "1.0.145"
 wasm-bindgen-test = "0.3.50"
 proptest = "1.11.0"


### PR DESCRIPTION
Regenerated against current main; supersedes #9. Dev-dependency only (test-vector parsing).

Pinned to 1.0.145 deliberately rather than the current 1.0.151, which replaces the `ryu` dependency with a new crate `zmij` — tracked separately for review before adoption.

Verified locally: 89 passed / 0 failed / 3 ignored (baseline match), clippy `-D warnings` exit 0.