### PR TITLE
fix: enable getrandom js feature for wasm32 builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2340,6 +2340,7 @@ dependencies = [
 name = "hashsigs-rs"
 version = "0.2.0-rc1"
 dependencies = [
+ "getrandom 0.2.16",
  "js-sys",
  "proptest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,12 @@ zeroize = { version = "1.8", features = ["derive"] }
 tsify = { version = "=0.5.5", default-features = false, features = ["js"], optional = true }
 wasm-bindgen = { version = "=0.2.100", optional = true }
 
+# solana-program 4.x reaches getrandom 0.2 via solana-secp256k1-recover -> k256
+# -> rand_core. getrandom refuses to build for wasm32-unknown-unknown unless its
+# "js" feature is on. Target-gated so the on-chain BPF build is untouched.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
+
 [dev-dependencies]
 serde_json = "1.0.145"
 wasm-bindgen-test = "0.3.50"


### PR DESCRIPTION
Fixes the `ts-conformance` job, which has been failing on `main` since the Solana 4.x migration (#33).

`solana-program` 4.x reaches `getrandom` 0.2 through `solana-secp256k1-recover` -> `k256` -> `rand_core`, and getrandom hard-errors on `wasm32-unknown-unknown` unless its `js` feature is enabled:

```
error: the wasm*-unknown-unknown targets are not supported by default,
       you may need to enable the "js" feature
```

Gated to `cfg(target_arch = "wasm32")` so the native and on-chain BPF builds are untouched.

## Verification

- `cargo build --release --target wasm32-unknown-unknown --features wasm-bindings` now succeeds (was failing)
- native `cargo build --workspace` unaffected
- `cargo clippy --workspace --all-targets -- -D warnings` exit 0
- `Cargo.lock` gains one line

## How this got through

My local verification ran `cargo test --workspace --all-targets`, which does not build the wasm target. GitLab CI caught it; there are no GitHub Actions on this repo, so nothing flagged it before the merge.