### PR TITLE
ci: align rust image with toolchain, wire fmt gate

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,7 +83,7 @@ default:
 
 build-test:
   stage: test
-  image: rust:1.89.0
+  image: rust:1.95.0
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
@@ -98,19 +98,18 @@ build-test:
     # only when packaging via npm run build → build-wasm.sh.
     - cargo build --locked --release --target wasm32-unknown-unknown --features wasm-bindings
 
-# Static clippy gate. Profile features are mutually exclusive, so lint the same
-# feature set CI tests (wasm-bindings), not --all-features. NOTE: `cargo fmt --check`
-# is intentionally not wired in yet — the tree is not fully rustfmt-clean; add it in a
-# dedicated formatting pass so this gate does not fail on pre-existing style drift.
+# Static clippy and formatting gate. Profile features are mutually exclusive, so
+# lint the same feature set CI tests (wasm-bindings), not --all-features.
 clippy:
   stage: test
-  image: rust:1.89.0
+  image: rust:1.95.0
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
   before_script:
-    - rustup component add clippy
+    - rustup component add clippy rustfmt
   script:
+    - cargo fmt --check
     - cargo clippy --all-targets --features wasm-bindings --locked -- -D warnings
 
 # Conformance test against the BUILT package (dist/): loaders, exports map,
@@ -119,7 +118,7 @@ clippy:
 # again here.
 ts-conformance:
   stage: test
-  image: rust:1.89.0
+  image: rust:1.95.0
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
@@ -135,7 +134,7 @@ ts-conformance:
 # runner cannot build wasm and must not try to.
 build-package:
   stage: package
-  image: rust:1.89.0
+  image: rust:1.95.0
   # Inherits default tags [linux, x86_64] -> runs on the self-hosted Linux fleet.
   # Anchored semver, optional pre-release suffix (e.g. v0.2.0-rc1); rejects v1.2.3.4 / v1.2.3-foo trailing junk.
   rules:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,6 @@ wasm-bindgen = { version = "=0.2.100", optional = true }
 getrandom = { version = "0.2", features = ["js"] }
 
 [dev-dependencies]
-serde_json = "1.0.145"
+serde_json = "1.0.151"
 wasm-bindgen-test = "0.3.50"
 proptest = "1.11.0"


### PR DESCRIPTION
Three places where a declared version had drifted from reality after today's changes.

**CI rust image.** `.gitlab-ci.yml` pinned `rust:1.89.0` across four jobs while `rust-toolchain.toml` moved to 1.95.0 in #33. Jobs did not fail — rustup auto-downloads the pinned toolchain inside the container — but each one paid for the download. Now `rust:1.95.0`.

**Formatting gate.** The clippy job carried this comment:

> NOTE: `cargo fmt --check` is intentionally not wired in yet — the tree is not fully rustfmt-clean; add it in a dedicated formatting pass so this gate does not fail on pre-existing style drift.

#35 was that pass. The gate is now wired in and the comment removed.

**serde_json.** `Cargo.toml` declared 1.0.145 while `Cargo.lock` has resolved 1.0.151 since #33's workspace update. This aligns the manifest; **`Cargo.lock` is unchanged**.

Note 1.0.151 replaces `ryu` with `zmij` for float formatting. Both are dtolnay crates (`zmij` differentially tests against `ryu`), `serde_json` here is a dev-dependency used only for test-vector parsing, and those vectors contain no floats — so the swapped code path is never exercised.

## Verification

Ran CI's exact commands locally:
- `cargo fmt --check` — clean
- `cargo clippy --all-targets --features wasm-bindings --locked -- -D warnings` — exit 0

Note that clippy invocation uses `--features wasm-bindings`, a different feature set than `--workspace --all-targets`.